### PR TITLE
Add portable CMake and native Windows lifecycle for V850E2M

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 athrill2
 RELEASE/
 build/
+.hako/
+__pycache__/
+*.pyc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ if(WIN32)
             "Configure from PowerShell with the vcpkg toolchain.")
     endif()
     find_package(PThreads4W CONFIG REQUIRED)
-    find_package(getopt CONFIG REQUIRED)
 else()
     find_package(Threads REQUIRED)
 endif()
@@ -85,7 +84,6 @@ if(WIN32)
     target_compile_definitions(athrill_host_platform INTERFACE PTW32_STATIC_LIB)
     target_link_libraries(athrill_host_platform INTERFACE
         PThreads4W::PThreads4W
-        getopt::getopt_static
         ws2_32
     )
 else()
@@ -297,6 +295,16 @@ install(TARGETS athrill2
 
 if(BUILD_TESTING)
     add_test(NAME athrill2-usage COMMAND athrill2)
+
+    add_executable(athrill-argument-parser-test
+        "test/argument_parser_test.c"
+        "${ATHRILL_SRC_DIR}/main/option/argument_parser.c"
+    )
+    target_include_directories(athrill-argument-parser-test PRIVATE
+        "${ATHRILL_SRC_DIR}/main/option"
+    )
+    athrill_apply_common_settings(athrill-argument-parser-test)
+    add_test(NAME athrill-argument-parser COMMAND athrill-argument-parser-test)
 endif()
 
 message(STATUS "Athrill source: ${ATHRILL_ROOT}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,29 +31,10 @@ include("${_athrill_cmake_module}")
 
 set(ATHRILL_TARGET_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-if(WIN32)
-    set(_athrill_exdev_default OFF)
-    set(_athrill_mros_default OFF)
-else()
-    set(_athrill_exdev_default ON)
-    set(_athrill_mros_default ON)
-endif()
-
-option(ATHRILL_ENABLE_EXDEV "Enable external device loading" ${_athrill_exdev_default})
-option(ATHRILL_ENABLE_MROS "Build the legacy mROS integration" ${_athrill_mros_default})
+option(ATHRILL_ENABLE_EXDEV "Enable external device loading" ON)
+option(ATHRILL_ENABLE_MROS "Build the legacy mROS integration" OFF)
 option(ATHRILL_ENABLE_VDEV "Enable the legacy VDEV implementation" OFF)
 
-if(WIN32 AND ATHRILL_ENABLE_EXDEV)
-    message(FATAL_ERROR "ATHRILL_ENABLE_EXDEV is not yet supported on Windows")
-endif()
-if(NOT WIN32 AND NOT ATHRILL_ENABLE_EXDEV)
-    message(FATAL_ERROR
-        "The current POSIX V850E2M implementation requires ATHRILL_ENABLE_EXDEV=ON")
-endif()
-if(NOT WIN32 AND NOT ATHRILL_ENABLE_MROS)
-    message(FATAL_ERROR
-        "The current POSIX V850E2M implementation requires ATHRILL_ENABLE_MROS=ON")
-endif()
 if(ATHRILL_ENABLE_VDEV)
     message(FATAL_ERROR "ATHRILL_ENABLE_VDEV is not yet supported by the CMake build")
 endif()
@@ -176,6 +157,9 @@ set(_athrill_device_sources
 )
 if(ATHRILL_ENABLE_EXDEV)
     list(APPEND _athrill_device_sources ${ATHRILL_DEVICE_EXDEV_SOURCES})
+    if(NOT WIN32)
+        list(APPEND _athrill_device_sources ${ATHRILL_DEVICE_EXDEV_POSIX_SOURCES})
+    endif()
 endif()
 if(ATHRILL_ENABLE_MROS)
     list(APPEND _athrill_device_sources
@@ -305,6 +289,35 @@ if(BUILD_TESTING)
     )
     athrill_apply_common_settings(athrill-argument-parser-test)
     add_test(NAME athrill-argument-parser COMMAND athrill-argument-parser-test)
+
+    if(ATHRILL_ENABLE_EXDEV)
+        add_library(athrill-exdev-test-device SHARED
+            "test/exdev_test_device.c"
+        )
+        target_include_directories(athrill-exdev-test-device PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/test"
+        )
+        athrill_apply_common_settings(athrill-exdev-test-device)
+        set_target_properties(athrill-exdev-test-device PROPERTIES
+            PREFIX ""
+        )
+
+        add_executable(athrill-shared-library-test
+            "test/shared_library_test.c"
+            "${ATHRILL_SRC_DIR}/lib/shared_library.c"
+        )
+        target_include_directories(athrill-shared-library-test PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/test"
+        )
+        athrill_apply_common_settings(athrill-shared-library-test)
+        target_link_libraries(athrill-shared-library-test PRIVATE
+            ${CMAKE_DL_LIBS}
+        )
+        add_test(NAME athrill-exdev-shared-library
+            COMMAND athrill-shared-library-test
+                $<TARGET_FILE:athrill-exdev-test-device>
+        )
+    endif()
 endif()
 
 message(STATUS "Athrill source: ${ATHRILL_ROOT}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,307 +1,306 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
-project(athrill2)
+project(athrill2 VERSION 1.0.2 LANGUAGES C)
 
-set(CORE_DIR "athrill/src")
-set(APLDIR "athrill/apl")
-set(TARGET_DIR "src")
+include(GNUInstallDirs)
+include(CTest)
 
-include_directories("${CORE_DIR}/inc" "${CORE_DIR}/lib" )
-
-if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
-    add_definitions(-DOS_LINUX -DSUPRESS_DETECT_WARNING_MESSAGE)
-    message(STATUS "CMAKE_HOST_SYSTEM_NAME is Linux")
-elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
-    add_definitions(-DOS_LINUX -DOS_MAC -DSUPRESS_DETECT_WARNING_MESSAGE)
-    message(STATUS "CMAKE_HOST_SYSTEM_NAME is Darwin")
+if(WIN32)
+    if(NOT MSVC)
+        message(FATAL_ERROR
+            "The supported native Windows toolchain is MSVC. "
+            "Configure from PowerShell with the vcpkg toolchain.")
+    endif()
+    find_package(PThreads4W CONFIG REQUIRED)
+    find_package(getopt CONFIG REQUIRED)
 else()
-    add_definitions()
-    message(STATUS "CMAKE_HOST_SYSTEM_NAME is others")
+    find_package(Threads REQUIRED)
 endif()
 
-add_definitions(-D DISABLE_DEVICE_VDEV -D CPUEMU_CLOCK_BUG_FIX -DSEARCH_REGION_OPTIMIZE -DCPU_PERMISSION_OPTIMIZE -DDISABLE_SERIAL_CLOCK -DDISABLE_BUS_ACCESS_LOG -DOPTIMIZE_USE_ONLY_1CPU -DMINIMUM_DEVICE_CONFIG -DENABLE_REUSE_UDP_SOCKET -DEXDEV_ENABLE)
+set(ATHRILL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/athrill"
+    CACHE PATH "Path to the Athrill common source repository")
+get_filename_component(ATHRILL_SOURCE_DIR "${ATHRILL_SOURCE_DIR}" ABSOLUTE
+    BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -g -Wall -Wunknown-pragmas -Wimplicit-int -Wtrigraphs -std=gnu99 -O3")
+set(_athrill_cmake_module "${ATHRILL_SOURCE_DIR}/cmake/AthrillCore.cmake")
+if(NOT EXISTS "${_athrill_cmake_module}")
+    message(FATAL_ERROR
+        "Athrill common CMake module was not found: ${_athrill_cmake_module}\n"
+        "Set ATHRILL_SOURCE_DIR to a compatible Athrill checkout.")
+endif()
+include("${_athrill_cmake_module}")
 
+set(ATHRILL_TARGET_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-add_library(main)
-target_include_directories(main PUBLIC  
-    "${CORE_DIR}/lib/dwarf" 
-    "${CORE_DIR}/bus" 
-    "${CORE_DIR}/device/mpu" 
-    "${CORE_DIR}/debugger/interaction" 
-    "${CORE_DIR}/debugger/interaction/inc" 
-    "${CORE_DIR}/debugger/executor"
-    "${CORE_DIR}/cpu"
-    "${CORE_DIR}/main"
-    "${TARGET_DIR}/cpu" 
-    "${TARGET_DIR}/cpu/config" 
-    "${TARGET_DIR}/debugger/interaction/inc" 
-)
-target_sources(main PRIVATE
-    "${CORE_DIR}/main/main.c"
-    "${CORE_DIR}/main/cpuemu.c"
-    "${CORE_DIR}/main/option/option.c"
-    "${CORE_DIR}/debugger/executor/cpu_control/dbg_cpu_callback.c"
-    "${CORE_DIR}/debugger/executor/cpu_control/dbg_cpu_control.c"
-    "${CORE_DIR}/debugger/executor/cpu_control/dbg_cpu_thread_control.c"
-)
-
-
-add_library(cui)
-target_include_directories(cui PRIVATE  
-    "${CORE_DIR}/lib/dwarf" 
-    "${CORE_DIR}/debugger/interaction" 
-    "${CORE_DIR}/debugger/interaction/inc" 
-    "${CORE_DIR}/debugger/executor" 
-    "${CORE_DIR}/debugger/executor/concrete_executor/target"
-    "${CORE_DIR}/cpu"
-    "${TARGET_DIR}/cpu" 
-    "${TARGET_DIR}/cpu/config" 
-    "${TARGET_DIR}/debugger/interaction/inc" 
-)
-target_sources(cui PRIVATE
-    "${CORE_DIR}/lib/cui/cui_ops.c" 
-    "${CORE_DIR}/lib/cui/stdio/cui_ops_stdio.c" 
-    "${CORE_DIR}/lib/cui/udp/cui_ops_udp.c"
-    "${CORE_DIR}/debugger/interaction/front/parser/dbg_parser_config.c" 
-    "${CORE_DIR}/debugger/interaction/front/parser/dbg_parser.c" 
-    "${CORE_DIR}/debugger/interaction/front/parser/concrete_parser/dbg_std_parser.c" 
-    "${CORE_DIR}/debugger/executor/concrete_executor/dbg_std_executor.c" 
-    "${CORE_DIR}/debugger/executor/concrete_executor/util/dbg_print_data_type.c"
-)
-
-
-add_library(cpu)
-target_include_directories(cpu PRIVATE  
-    "${CORE_DIR}/cpu" 
-    "${CORE_DIR}/bus" 
-    "${CORE_DIR}/device/mpu" 
-    "${TARGET_DIR}/cpu" 
-    "${TARGET_DIR}/cpu/config" 
-    "${TARGET_DIR}/cpu/cpu_exec" 
-    "${TARGET_DIR}/cpu/cpu_dec"
-    "${TARGET_DIR}/cpu/cpu_common" 
-    "${TARGET_DIR}/device"
-)
-target_sources(cpu PRIVATE
-    "${TARGET_DIR}/cpu/cpu_exec/op_exec_bit.c" 
-    "${TARGET_DIR}/cpu/cpu_exec/op_exec_branch.c" 
-    "${TARGET_DIR}/cpu/cpu_exec/op_exec_dbg.c" 
-    "${TARGET_DIR}/cpu/cpu_exec/op_exec_div.c" 
-    "${TARGET_DIR}/cpu/cpu_exec/op_exec_logic.c" 
-    "${TARGET_DIR}/cpu/cpu_exec/op_exec_arithm.c" 
-    "${TARGET_DIR}/cpu/cpu_exec/op_exec_store.c" 
-    "${TARGET_DIR}/cpu/cpu_exec/op_exec_load.c" 
-    "${TARGET_DIR}/cpu/cpu_exec/op_exec_spec.c" 
-    "${TARGET_DIR}/cpu/cpu_exec/op_exec_fpu.c" 
-    "${TARGET_DIR}/cpu/cpu_exec/op_exec.c" 
-    "${TARGET_DIR}/cpu/cpu_exec/op_exec_sat.c" 
-    "${TARGET_DIR}/cpu/cpu_dec/op_dec.c" 
-    "${TARGET_DIR}/cpu/cpu_dec/op_parse.c" 
-    "${TARGET_DIR}/cpu/cpu_dec/op_parse_private.c" 
-    "${TARGET_DIR}/cpu/config/cpu_config.c"
-    "${CORE_DIR}/lib/dbg_log.c"
-)
-
-
-add_library(device)
-target_include_directories(device PRIVATE  
-    "${CORE_DIR}/cpu" 
-    "${CORE_DIR}/device/mpu" 
-    "${CORE_DIR}/debugger/executor" 
-    "${CORE_DIR}/device/peripheral/target" 
-    "${CORE_DIR}/device/peripheral/mros-dev/mros-athrill/api" 
-    "${CORE_DIR}/device/peripheral/mros-dev/mros-athrill/device" 
-    "${CORE_DIR}/device/peripheral/mros-dev/mros-athrill/target/os" 
-    "${CORE_DIR}/device/peripheral/mros-dev/mros-src/os/target/os_asp" 
-    "${CORE_DIR}/device/peripheral/serial/fifo" 
-    "${APLDIR}/include"
-    "${TARGET_DIR}/cpu" 
-    "${TARGET_DIR}/cpu/config" 
-    "${TARGET_DIR}/device"
-    "${TARGET_DIR}/device/intc" 
-    "${TARGET_DIR}/device/intc/gic" 
-    "${TARGET_DIR}/device/intc/register"
-    "${TARGET_DIR}/device/peripheral" 
-    "${TARGET_DIR}/device/peripheral/inc"
-)
-target_sources(device PRIVATE
-    "${CORE_DIR}/device/peripheral/serial/fifo/serial_fifo.c"
-    "${TARGET_DIR}/device/device.c"
-    "${TARGET_DIR}/device/intc/intc.c"
-    "${TARGET_DIR}/device/peripheral/timer/timer32.c"
-    "${TARGET_DIR}/device/peripheral/serial/serial.c"
-    "${TARGET_DIR}/device/peripheral/can/can.c"
-    "${TARGET_DIR}/debugger/executor/concrete_executor/dbg_target_serial.c"
-    "${TARGET_DIR}/debugger/executor/concrete_executor/dbg_target_cpu.c"
-)
-if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+if(WIN32)
+    set(_athrill_exdev_default OFF)
+    set(_athrill_mros_default OFF)
 else()
-target_sources(device PRIVATE
-    "${CORE_DIR}/device/peripheral/athrill_device.c" 
-    "${CORE_DIR}/device/peripheral/athrill_syscall_device.c" 
-    "${CORE_DIR}/device/peripheral/athrill_mpthread.c" 
-)
+    set(_athrill_exdev_default ON)
+    set(_athrill_mros_default ON)
 endif()
 
-add_library(bus)
-target_include_directories(bus PRIVATE  
-    "${CORE_DIR}/device/mpu" 
-)
-target_sources(bus PRIVATE
-    "${CORE_DIR}/bus/bus.c"
-)
-# add_subdirectory(${CORE_DIR}/bus)
+option(ATHRILL_ENABLE_EXDEV "Enable external device loading" ${_athrill_exdev_default})
+option(ATHRILL_ENABLE_MROS "Build the legacy mROS integration" ${_athrill_mros_default})
+option(ATHRILL_ENABLE_VDEV "Enable the legacy VDEV implementation" OFF)
 
-add_library(loader)
-target_include_directories(loader PRIVATE  
-    "${CORE_DIR}/lib/dwarf" 
-    "${CORE_DIR}/cpu" 
-    "${TARGET_DIR}/cpu" 
-    "${TARGET_DIR}/cpu/config"
-)
-target_sources(loader PRIVATE
-    "${CORE_DIR}/lib/symbol_ops.c"
-    "${CORE_DIR}/lib/dwarf/elf_section.c" 
-    "${CORE_DIR}/lib/dwarf/elf_dwarf_line.c" 
-    "${CORE_DIR}/lib/dwarf/elf_dwarf_loc.c" 
-    "${CORE_DIR}/lib/dwarf/elf_dwarf_info.c" 
-    "${CORE_DIR}/lib/dwarf/elf_dwarf_abbrev.c" 
-    "${CORE_DIR}/lib/dwarf/elf_dwarf_util.c" 
-    "${CORE_DIR}/lib/dwarf/elf_dwarf_info_ops.c" 
-    "${CORE_DIR}/lib/dwarf/file_address_mapping.c" 
-    "${CORE_DIR}/lib/dwarf/data_type/elf_dwarf_data_type.c"
-    "${CORE_DIR}/lib/dwarf/data_type/elf_dwarf_base_type.c"
-    "${CORE_DIR}/lib/dwarf/data_type/elf_dwarf_typedef_type.c"
-    "${CORE_DIR}/lib/dwarf/data_type/elf_dwarf_pointer_type.c"
-    "${CORE_DIR}/lib/dwarf/data_type/elf_dwarf_struct_type.c"
-    "${CORE_DIR}/lib/dwarf/data_type/elf_dwarf_enum_type.c"
-    "${CORE_DIR}/lib/dwarf/data_type/elf_dwarf_array_type.c"
-    "${CORE_DIR}/lib/dwarf/data_type/elf_dwarf_variable_type.c"
-    "${CORE_DIR}/lib/dwarf/data_type/elf_dwarf_subprogram_type.c"
-)
-
-
-add_library(mpu ${MPU-SRC})
-target_include_directories(mpu PRIVATE  
-    "${CORE_DIR}/device/mpu" 
-    "${CORE_DIR}/device/peripheral/serial/fifo" 
-    "${CORE_DIR}/cpu" 
-    "${CORE_DIR}/lib/dwarf" 
-    "${CORE_DIR}/lib/dwarf/data_type" 
-    "${TARGET_DIR}/cpu" 
-    "${TARGET_DIR}/cpu/config" 
-)
-target_sources(mpu PRIVATE
-    "${CORE_DIR}/device/mpu/mpu.c" 
-    "${CORE_DIR}/device/mpu/mpu_malloc.c" 
-    "${CORE_DIR}/device/mpu/loader/loader.c"
-    "${TARGET_DIR}/cpu/config/mpu_config.c"
-)
-
-
-add_library(std)
-target_sources(std PRIVATE
-    "${CORE_DIR}/lib/hash.c" 
-    "${CORE_DIR}/lib/token.c" 
-    "${CORE_DIR}/lib/file.c" 
-    "${CORE_DIR}/lib/winsock_wrapper/winsock_wrapper.c"
-    "${CORE_DIR}/lib/udp/udp_comm.c" 
-)
-if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
-else()
-target_sources(std PRIVATE
-    "${CORE_DIR}/lib/comm_buffer.c" 
-    "${CORE_DIR}/lib/tcp/tcp_socket.c"
-    "${CORE_DIR}/lib/tcp/tcp_client.c"
-    "${CORE_DIR}/lib/tcp/tcp_connection.c"
-    "${CORE_DIR}/lib/tcp/tcp_server.c"
-)
+if(WIN32 AND ATHRILL_ENABLE_EXDEV)
+    message(FATAL_ERROR "ATHRILL_ENABLE_EXDEV is not yet supported on Windows")
+endif()
+if(NOT WIN32 AND NOT ATHRILL_ENABLE_EXDEV)
+    message(FATAL_ERROR
+        "The current POSIX V850E2M implementation requires ATHRILL_ENABLE_EXDEV=ON")
+endif()
+if(NOT WIN32 AND NOT ATHRILL_ENABLE_MROS)
+    message(FATAL_ERROR
+        "The current POSIX V850E2M implementation requires ATHRILL_ENABLE_MROS=ON")
+endif()
+if(ATHRILL_ENABLE_VDEV)
+    message(FATAL_ERROR "ATHRILL_ENABLE_VDEV is not yet supported by the CMake build")
 endif()
 
-if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
-else()
-set(MROS_SRC "${CORE_DIR}/device/peripheral/mros-dev/mros-src")
-set(MROS_DEV "${CORE_DIR}/device/peripheral/mros-dev/mros-athrill")
-set(ROS_VERSION	"kinetic")
+add_library(athrill_v850_build_config INTERFACE)
+target_compile_definitions(athrill_v850_build_config INTERFACE
+    CPUEMU_CLOCK_BUG_FIX
+    SEARCH_REGION_OPTIMIZE
+    CPU_PERMISSION_OPTIMIZE
+    DISABLE_SERIAL_CLOCK
+    DISABLE_BUS_ACCESS_LOG
+    OPTIMIZE_USE_ONLY_1CPU
+    MINIMUM_DEVICE_CONFIG
+    ENABLE_REUSE_UDP_SOCKET
+)
+if(ATHRILL_ENABLE_EXDEV)
+    target_compile_definitions(athrill_v850_build_config INTERFACE EXDEV_ENABLE)
+endif()
+if(NOT ATHRILL_ENABLE_MROS)
+    target_compile_definitions(athrill_v850_build_config INTERFACE DISABLE_CAN)
+endif()
+if(NOT ATHRILL_ENABLE_VDEV)
+    target_compile_definitions(athrill_v850_build_config INTERFACE DISABLE_DEVICE_VDEV)
+endif()
 
-add_library(mros)
-target_include_directories(mros PRIVATE  
-    "${TARGET_DIR}/cpu" 
-    "${TARGET_DIR}/cpu/config"
-    "${MROS_SRC}/api" 
-    "${MROS_SRC}/inc" 
-    "${MROS_SRC}/os/target/os_asp" 
-    "${MROS_SRC}/protocol/cimpl" 
-    "${MROS_SRC}/node/cimpl"
-    "${MROS_SRC}/topic/cimpl" 
-    "${MROS_SRC}/comm/cimpl/target/lwip" 
-    "${MROS_SRC}/comm/cimpl" 
-    "${MROS_SRC}/packet/cimpl"
-    "${MROS_SRC}/packet/template/version/${ROS_VERSION}" 
-    "${MROS_SRC}/packet/cimpl/version/${ROS_VERSION}" 
-    "${MROS_SRC}/transfer/cimpl"
-    "${MROS_DEV}/api" 
-    "${MROS_DEV}/config" 
-    "${MROS_DEV}/config/os/target/os_asp" 
-    "${MROS_DEV}/target" 
-    "${MROS_DEV}/target/os"
-    "${MROS_DEV}/device"
-)
-target_compile_options(mros PRIVATE
-    -DTARGET_ATHRILL
-    -DLWIP_TRANSPORT_ETHERNET
-)
-target_sources(mros PRIVATE
-    "${MROS_SRC}/comm/cimpl/mros_comm_socket_cimpl.c"
-    "${MROS_SRC}/comm/cimpl/mros_comm_tcp_client_cimpl.c"
-    "${MROS_SRC}/comm/cimpl/mros_comm_tcp_client_factory_cimpl.c"
-    "${MROS_SRC}/comm/cimpl/mros_comm_tcp_server_cimpl.c"
-    "${MROS_SRC}/comm/cimpl/target/lwip/mros_comm_cimpl.c"
-    "${MROS_SRC}/lib/mros_memory.c"
-    "${MROS_SRC}/lib/mros_wait_queue.c"
-    "${MROS_SRC}/lib/mros_memory.c"
-    "${MROS_SRC}/lib/mros_name.c"
-    "${MROS_SRC}/node/cimpl/mros_node_cimpl.c"
-    "${MROS_SRC}/os/mros_exclusive_area.c"
-    "${MROS_SRC}/os/target/os_asp/mros_os.c"
-    "${MROS_SRC}/packet/cimpl/version/${ROS_VERSION}/mros_packet_decoder_cimpl.c"
-    "${MROS_SRC}/packet/cimpl/version/${ROS_VERSION}/mros_packet_encoder_cimpl.c"
-    "${MROS_SRC}/protocol/cimpl/mros_protocol_client_rpc_cimpl.c"
-    "${MROS_SRC}/protocol/cimpl/mros_protocol_operation_cimpl.c"
-    "${MROS_SRC}/protocol/cimpl/mros_protocol_publish_cimpl.c"
-    "${MROS_SRC}/protocol/cimpl/mros_protocol_server_proc_cimpl.c"
-    "${MROS_SRC}/protocol/cimpl/mros_protocol_slave_cimpl.c"
-    "${MROS_SRC}/protocol/cimpl/mros_protocol_subscribe_cimpl.c"
-    "${MROS_SRC}/protocol/cimpl/mros_protocol_master_cimpl.c"
-    "${MROS_SRC}/topic/cimpl/mros_topic_cimpl.c"
-    "${MROS_SRC}/topic/cimpl/mros_topic_connector_cimpl.c"
-    "${MROS_SRC}/topic/cimpl/mros_topic_connector_factory_cimpl.c"
-    "${MROS_SRC}/transfer/cimpl/mros_topic_data_publisher_cimpl.c"
-    "${MROS_SRC}/transfer/cimpl/mros_topic_data_subscriber_cimpl.c"
-    "${MROS_SRC}/transfer/cimpl/mros_topic_data_publisher_cimpl.c"
-    "${MROS_DEV}/api/ros_cimpl.c"
-    "${MROS_DEV}/device/athrill_mros_device.c"
-    "${MROS_DEV}/config/mros_sys_config.c"
-    "${MROS_DEV}/config/os/target/os_asp/mros_os_config.c"
-    "${MROS_DEV}/target/os/os_asp.c"
-    "${MROS_DEV}/target/os/mros_exclusive_ops_linux.c"
-    "${MROS_DEV}/target/lwip/lwip_linux.c"
+add_library(athrill_host_platform INTERFACE)
+if(WIN32)
+    target_compile_definitions(athrill_host_platform INTERFACE PTW32_STATIC_LIB)
+    target_link_libraries(athrill_host_platform INTERFACE
+        PThreads4W::PThreads4W
+        getopt::getopt_static
+        ws2_32
+    )
+else()
+    target_link_libraries(athrill_host_platform INTERFACE
+        Threads::Threads
+        m
+        ${CMAKE_DL_LIBS}
     )
 endif()
 
-# add_subdirectory(${CORE_DIR}/device/peripheral/mros-dev)
+function(athrill_v850_configure_target target_name)
+    athrill_apply_common_settings("${target_name}")
+    target_link_libraries("${target_name}" PRIVATE
+        athrill_v850_build_config
+        athrill_host_platform
+    )
+endfunction()
 
-add_executable(athrill2 "${CORE_DIR}/main/main.c")
-target_include_directories(athrill2 INTERFACE main)
-if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
-target_link_libraries(athrill2 main cui cpu device bus loader mpu std pthread wsock32)
-else()
-target_link_libraries(athrill2 main cui cpu device bus loader mpu std mros pthread m dl)
+add_library(athrill_main STATIC ${ATHRILL_MAIN_SOURCES})
+target_include_directories(athrill_main PRIVATE
+    "${ATHRILL_SRC_DIR}/lib/dwarf"
+    "${ATHRILL_SRC_DIR}/bus"
+    "${ATHRILL_SRC_DIR}/device/mpu"
+    "${ATHRILL_SRC_DIR}/debugger/interaction"
+    "${ATHRILL_SRC_DIR}/debugger/interaction/inc"
+    "${ATHRILL_SRC_DIR}/debugger/executor"
+    "${ATHRILL_SRC_DIR}/cpu"
+    "${ATHRILL_SRC_DIR}/main"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/config"
+    "${ATHRILL_TARGET_SOURCE_DIR}/debugger/interaction/inc"
+)
+athrill_v850_configure_target(athrill_main)
+
+add_library(athrill_cui STATIC ${ATHRILL_CUI_SOURCES})
+target_include_directories(athrill_cui PRIVATE
+    "${ATHRILL_SRC_DIR}/lib/dwarf"
+    "${ATHRILL_SRC_DIR}/debugger/interaction"
+    "${ATHRILL_SRC_DIR}/debugger/interaction/inc"
+    "${ATHRILL_SRC_DIR}/debugger/executor"
+    "${ATHRILL_SRC_DIR}/debugger/executor/concrete_executor/target"
+    "${ATHRILL_SRC_DIR}/cpu"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/config"
+    "${ATHRILL_TARGET_SOURCE_DIR}/debugger/interaction/inc"
+)
+athrill_v850_configure_target(athrill_cui)
+
+add_library(athrill_v850_cpu STATIC
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_exec/op_exec_bit.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_exec/op_exec_branch.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_exec/op_exec_dbg.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_exec/op_exec_div.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_exec/op_exec_logic.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_exec/op_exec_arithm.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_exec/op_exec_store.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_exec/op_exec_load.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_exec/op_exec_spec.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_exec/op_exec_fpu.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_exec/op_exec.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_exec/op_exec_sat.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_dec/op_dec.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_dec/op_parse.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_dec/op_parse_private.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/config/cpu_config.c"
+    "${ATHRILL_SRC_DIR}/lib/dbg_log.c"
+)
+target_include_directories(athrill_v850_cpu PRIVATE
+    "${ATHRILL_SRC_DIR}/cpu"
+    "${ATHRILL_SRC_DIR}/bus"
+    "${ATHRILL_SRC_DIR}/device/mpu"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/config"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_exec"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_dec"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/cpu_common"
+    "${ATHRILL_TARGET_SOURCE_DIR}/device"
+)
+athrill_v850_configure_target(athrill_v850_cpu)
+
+set(_athrill_device_sources
+    ${ATHRILL_DEVICE_COMMON_SOURCES}
+    ${ATHRILL_DEVICE_THREAD_SOURCES}
+    "${ATHRILL_TARGET_SOURCE_DIR}/device/device.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/device/intc/intc.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/device/peripheral/timer/timer32.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/device/peripheral/serial/serial.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/debugger/executor/concrete_executor/dbg_target_serial.c"
+    "${ATHRILL_TARGET_SOURCE_DIR}/debugger/executor/concrete_executor/dbg_target_cpu.c"
+)
+if(ATHRILL_ENABLE_EXDEV)
+    list(APPEND _athrill_device_sources ${ATHRILL_DEVICE_EXDEV_SOURCES})
+endif()
+if(ATHRILL_ENABLE_MROS)
+    list(APPEND _athrill_device_sources
+        "${ATHRILL_TARGET_SOURCE_DIR}/device/peripheral/can/can.c")
 endif()
 
-# install(TARGETS main)
+add_library(athrill_v850_device STATIC ${_athrill_device_sources})
+target_include_directories(athrill_v850_device PRIVATE
+    "${ATHRILL_SRC_DIR}/cpu"
+    "${ATHRILL_SRC_DIR}/device/mpu"
+    "${ATHRILL_SRC_DIR}/debugger/executor"
+    "${ATHRILL_SRC_DIR}/device/peripheral/target"
+    "${ATHRILL_SRC_DIR}/device/peripheral/mros-dev/mros-athrill/api"
+    "${ATHRILL_SRC_DIR}/device/peripheral/mros-dev/mros-athrill/device"
+    "${ATHRILL_SRC_DIR}/device/peripheral/mros-dev/mros-athrill/target/os"
+    "${ATHRILL_SRC_DIR}/device/peripheral/mros-dev/mros-src/os/target/os_asp"
+    "${ATHRILL_SRC_DIR}/device/peripheral/serial/fifo"
+    "${ATHRILL_APL_DIR}/include"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/config"
+    "${ATHRILL_TARGET_SOURCE_DIR}/device"
+    "${ATHRILL_TARGET_SOURCE_DIR}/device/intc"
+    "${ATHRILL_TARGET_SOURCE_DIR}/device/intc/gic"
+    "${ATHRILL_TARGET_SOURCE_DIR}/device/intc/register"
+    "${ATHRILL_TARGET_SOURCE_DIR}/device/peripheral"
+    "${ATHRILL_TARGET_SOURCE_DIR}/device/peripheral/inc"
+)
+athrill_v850_configure_target(athrill_v850_device)
 
-# enable_testing()
-# add_test(NAME main COMMAND main)
+add_library(athrill_bus STATIC ${ATHRILL_BUS_SOURCES})
+target_include_directories(athrill_bus PRIVATE
+    "${ATHRILL_SRC_DIR}/device/mpu"
+)
+athrill_v850_configure_target(athrill_bus)
+
+add_library(athrill_loader STATIC ${ATHRILL_LOADER_SOURCES})
+target_include_directories(athrill_loader PRIVATE
+    "${ATHRILL_SRC_DIR}/lib/dwarf"
+    "${ATHRILL_SRC_DIR}/cpu"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/config"
+)
+athrill_v850_configure_target(athrill_loader)
+
+add_library(athrill_mpu STATIC
+    ${ATHRILL_MPU_SOURCES}
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/config/mpu_config.c"
+)
+target_include_directories(athrill_mpu PRIVATE
+    "${ATHRILL_SRC_DIR}/device/mpu"
+    "${ATHRILL_SRC_DIR}/device/peripheral/serial/fifo"
+    "${ATHRILL_SRC_DIR}/cpu"
+    "${ATHRILL_SRC_DIR}/lib/dwarf"
+    "${ATHRILL_SRC_DIR}/lib/dwarf/data_type"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/config"
+)
+athrill_v850_configure_target(athrill_mpu)
+
+set(_athrill_std_sources ${ATHRILL_STD_COMMON_SOURCES})
+if(NOT WIN32)
+    list(APPEND _athrill_std_sources ${ATHRILL_STD_POSIX_SOURCES})
+endif()
+add_library(athrill_std STATIC ${_athrill_std_sources})
+athrill_v850_configure_target(athrill_std)
+
+set(_athrill_optional_libraries)
+if(ATHRILL_ENABLE_MROS)
+    if(WIN32)
+        message(FATAL_ERROR "ATHRILL_ENABLE_MROS is not supported on Windows")
+    endif()
+    add_library(athrill_mros STATIC ${ATHRILL_MROS_SOURCES})
+    target_include_directories(athrill_mros PRIVATE
+        "${ATHRILL_TARGET_SOURCE_DIR}/cpu"
+        "${ATHRILL_TARGET_SOURCE_DIR}/cpu/config"
+        ${ATHRILL_MROS_INCLUDE_DIRS}
+    )
+    target_compile_definitions(athrill_mros PRIVATE
+        TARGET_ATHRILL
+        LWIP_TRANSPORT_ETHERNET
+    )
+    athrill_v850_configure_target(athrill_mros)
+    list(APPEND _athrill_optional_libraries athrill_mros)
+endif()
+
+add_executable(athrill2 "${ATHRILL_SRC_DIR}/main/main.c")
+target_include_directories(athrill2 PRIVATE
+    "${ATHRILL_SRC_DIR}/lib/dwarf"
+    "${ATHRILL_SRC_DIR}/bus"
+    "${ATHRILL_SRC_DIR}/cpu"
+    "${ATHRILL_SRC_DIR}/device/mpu"
+    "${ATHRILL_SRC_DIR}/debugger/interaction"
+    "${ATHRILL_SRC_DIR}/debugger/interaction/inc"
+    "${ATHRILL_SRC_DIR}/debugger/executor"
+    "${ATHRILL_SRC_DIR}/main"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu"
+    "${ATHRILL_TARGET_SOURCE_DIR}/cpu/config"
+    "${ATHRILL_TARGET_SOURCE_DIR}/debugger/interaction/inc"
+)
+athrill_v850_configure_target(athrill2)
+target_link_libraries(athrill2 PRIVATE
+    athrill_main
+    athrill_cui
+    athrill_v850_cpu
+    athrill_v850_device
+    athrill_bus
+    athrill_loader
+    athrill_mpu
+    athrill_std
+    ${_athrill_optional_libraries}
+    athrill_host_platform
+)
+
+install(TARGETS athrill2
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)
+
+if(BUILD_TESTING)
+    add_test(NAME athrill2-usage COMMAND athrill2)
+endif()
+
+message(STATUS "Athrill source: ${ATHRILL_ROOT}")
+message(STATUS "Athrill target: V850E2M")
+message(STATUS "Athrill EXDEV: ${ATHRILL_ENABLE_EXDEV}")
+message(STATUS "Athrill mROS: ${ATHRILL_ENABLE_MROS}")
+message(STATUS "Athrill VDEV: ${ATHRILL_ENABLE_VDEV}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,46 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 25,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "windows-msvc",
+      "displayName": "Windows x64 MSVC with vcpkg",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/.hako/build",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "cacheVariables": {
+        "ATHRILL_SOURCE_DIR": "${sourceDir}/../athrill",
+        "ATHRILL_ENABLE_EXDEV": "OFF",
+        "ATHRILL_ENABLE_MROS": "OFF",
+        "ATHRILL_ENABLE_VDEV": "OFF",
+        "BUILD_TESTING": "ON",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_TARGET_TRIPLET": "x64-windows-static"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "windows-msvc-release",
+      "configurePreset": "windows-msvc"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "windows-msvc-smoke",
+      "configurePreset": "windows-msvc",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,7 +18,7 @@
       },
       "cacheVariables": {
         "ATHRILL_SOURCE_DIR": "${sourceDir}/../athrill",
-        "ATHRILL_ENABLE_EXDEV": "OFF",
+        "ATHRILL_ENABLE_EXDEV": "ON",
         "ATHRILL_ENABLE_MROS": "OFF",
         "ATHRILL_ENABLE_VDEV": "OFF",
         "BUILD_TESTING": "ON",

--- a/README.md
+++ b/README.md
@@ -3,25 +3,55 @@
 
 v850e2m Target dependencies for [Athrill](https://github.com/toppers/athrill)
 ## Build
-Use Makefile
+
+The Business Pack-compatible entry point is:
+
+```shell
+python tools/hako.py doctor
+python tools/hako.py build
+python tools/hako.py smoke
+```
+
+The checked-in `hakoniwa-build.yaml` selects the sibling `../athrill`
+checkout and, on Windows, `C:\project\vcpkg`. The Windows driver locates
+Visual Studio, initializes the x64 developer environment, and maps a WSL UNC
+workspace before invoking CMake. Build settings can be overridden with
+`--config <manifest>`.
+
+To install the executable and emit a Business Pack Component Receipt:
+
+```shell
+python tools/hako.py --install-dir .hako/install install
+```
+
+The lower-level Windows presets remain available from a Visual Studio
+Developer PowerShell:
+
+```powershell
+$env:VCPKG_ROOT = 'C:\project\vcpkg'
+cmake --preset windows-msvc
+cmake --build --preset windows-msvc-release
+ctest --preset windows-msvc-smoke
+```
+
+### Legacy Make build
+
 ```
 git clone --recursive https://github.com/toppers/athrill-target-v850e2m
 cd athrill-target-v850e2m/build_linux
 make
 ```
 
-Use CMake
+### Generic CMake build
+
 ```
 git clone --recursive https://github.com/toppers/athrill-target-v850e2m
-mkdir -p athrill-target-v850e2m/build
-cd athrill-target-v850e2m/build
-cmake -H..
-make
+cmake -S athrill-target-v850e2m -B athrill-target-v850e2m/build
+cmake --build athrill-target-v850e2m/build
 ```
 
 
 ## License
 
 This repository is distributed with [TOPPERS License](https://toppers.jp/en/license.html).
-
 

--- a/hakoniwa-build.yaml
+++ b/hakoniwa-build.yaml
@@ -1,0 +1,18 @@
+version: 1
+
+build:
+  type: Release
+  dir: .hako/build
+  parallel: 0
+
+features:
+  exdev: auto
+  mros: auto
+  vdev: false
+
+validation:
+  tests: true
+
+paths:
+  athrill_root: ../athrill
+  vcpkg_root: C:\project\vcpkg

--- a/hakoniwa-build.yaml
+++ b/hakoniwa-build.yaml
@@ -6,8 +6,8 @@ build:
   parallel: 0
 
 features:
-  exdev: auto
-  mros: auto
+  exdev: true
+  mros: false
   vdev: false
 
 validation:

--- a/test/argument_parser_test.c
+++ b/test/argument_parser_test.c
@@ -1,0 +1,155 @@
+#include "argument_parser.h"
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/*
+ * Athrill's Windows compatibility headers declare assert as a function.
+ * Keep this standalone test independent of that runtime implementation.
+ */
+#undef assert
+#define assert(condition) \
+    do { \
+        if (!(condition)) { \
+            fprintf(stderr, "assertion failed at line %d: %s\\n", __LINE__, #condition); \
+            exit(EXIT_FAILURE); \
+        } \
+    } while (0)
+
+static void test_clustered_flags(void)
+{
+    const char *argv[] = {"athrill2", "-irb", "program.elf"};
+    ArgumentParserState state;
+
+    argument_parser_init(&state);
+    assert(argument_parser_next(&state, 3, argv, "irb") == 'i');
+    assert(argument_parser_next(&state, 3, argv, "irb") == 'r');
+    assert(argument_parser_next(&state, 3, argv, "irb") == 'b');
+    assert(argument_parser_next(&state, 3, argv, "irb") == -1);
+    assert(state.index == 2);
+}
+
+static void test_required_arguments(void)
+{
+    const char *argv[] = {"athrill2", "-t", "100", "-c3", "program.elf"};
+    ArgumentParserState state;
+
+    argument_parser_init(&state);
+    assert(argument_parser_next(&state, 5, argv, "t:c:") == 't');
+    assert(state.argument != NULL);
+    assert(state.argument[0] == '1');
+    assert(argument_parser_next(&state, 5, argv, "t:c:") == 'c');
+    assert(state.argument != NULL);
+    assert(state.argument[0] == '3');
+    assert(argument_parser_next(&state, 5, argv, "t:c:") == -1);
+    assert(state.index == 4);
+}
+
+static void test_end_marker(void)
+{
+    const char *argv[] = {"athrill2", "-i", "--", "-program.elf"};
+    ArgumentParserState state;
+
+    argument_parser_init(&state);
+    assert(argument_parser_next(&state, 4, argv, "i") == 'i');
+    assert(argument_parser_next(&state, 4, argv, "i") == -1);
+    assert(state.index == 3);
+}
+
+static void test_unknown_option(void)
+{
+    const char *argv[] = {"athrill2", "-x", "program.elf"};
+    ArgumentParserState state;
+
+    argument_parser_init(&state);
+    assert(argument_parser_next(&state, 3, argv, "i") == '?');
+    assert(state.error_option == 'x');
+    assert(state.index == 2);
+}
+
+static void test_missing_argument(void)
+{
+    const char *argv[] = {"athrill2", "-t"};
+    ArgumentParserState state;
+
+    argument_parser_init(&state);
+    assert(argument_parser_next(&state, 2, argv, "t:") == '?');
+    assert(state.error_option == 't');
+    assert(state.argument == NULL);
+    assert(state.index == 2);
+}
+
+static void test_non_option_stops_parser(void)
+{
+    const char *argv[] = {"athrill2", "program.elf", "-i"};
+    ArgumentParserState state;
+
+    argument_parser_init(&state);
+    assert(argument_parser_next(&state, 3, argv, "i") == -1);
+    assert(state.index == 1);
+}
+
+static void test_long_options(void)
+{
+    const char *argv[] = {
+        "athrill_remote",
+        "--verbose",
+        "--athrill-listen-port=1234",
+        "--remote-client-listen-port",
+        "5678",
+        "status"
+    };
+    const ArgumentParserLongOption options[] = {
+        {"athrill-listen-port", 1, 'a'},
+        {"remote-client-listen-port", 1, 'r'},
+        {"verbose", 0, 'v'},
+        {NULL, 0, 0}
+    };
+    ArgumentParserState state;
+
+    argument_parser_init(&state);
+    assert(argument_parser_next_long(&state, 6, argv, "a:r:v", options) == 'v');
+    assert(argument_parser_next_long(&state, 6, argv, "a:r:v", options) == 'a');
+    assert(state.argument[0] == '1');
+    assert(argument_parser_next_long(&state, 6, argv, "a:r:v", options) == 'r');
+    assert(state.argument[0] == '5');
+    assert(argument_parser_next_long(&state, 6, argv, "a:r:v", options) == -1);
+    assert(state.index == 5);
+}
+
+static void test_invalid_long_option(void)
+{
+    const char *unknown_argv[] = {"athrill_remote", "--unknown"};
+    const char *missing_argv[] = {"athrill_remote", "--port"};
+    const char *unexpected_argv[] = {"athrill_remote", "--verbose=yes"};
+    const ArgumentParserLongOption options[] = {
+        {"port", 1, 'p'},
+        {"verbose", 0, 'v'},
+        {NULL, 0, 0}
+    };
+    ArgumentParserState state;
+
+    argument_parser_init(&state);
+    assert(argument_parser_next_long(&state, 2, unknown_argv, "p:v", options) == '?');
+    argument_parser_init(&state);
+    assert(argument_parser_next_long(&state, 2, missing_argv, "p:v", options) == '?');
+    assert(state.error_option == 'p');
+    argument_parser_init(&state);
+    assert(argument_parser_next_long(&state, 2, unexpected_argv, "p:v", options) == '?');
+    assert(state.error_option == 'v');
+}
+
+int main(void)
+{
+    test_clustered_flags();
+    test_required_arguments();
+    test_end_marker();
+    test_unknown_option();
+    test_missing_argument();
+    test_non_option_stops_parser();
+    test_long_options();
+    test_invalid_long_option();
+    return 0;
+}

--- a/test/exdev_test_abi.h
+++ b/test/exdev_test_abi.h
@@ -1,0 +1,17 @@
+#ifndef ATHRILL_EXDEV_TEST_ABI_H
+#define ATHRILL_EXDEV_TEST_ABI_H
+
+#include "athrill_exdev_header.h"
+
+typedef void (*AthrillExDevTestCallbackType)(void *);
+
+typedef struct {
+    AthrillExDeviceHeaderType header;
+    char *datap;
+    void *ops;
+    AthrillExDevTestCallbackType devinit;
+    AthrillExDevTestCallbackType supply_clock;
+    void (*cleanup)(void);
+} AthrillExDevTestDeviceType;
+
+#endif

--- a/test/exdev_test_device.c
+++ b/test/exdev_test_device.c
@@ -1,0 +1,35 @@
+#include "exdev_test_abi.h"
+
+#include <stddef.h>
+
+static char test_memory[64];
+
+static void test_devinit(void *unused)
+{
+    (void)unused;
+    test_memory[0] = 1;
+}
+
+static void test_supply_clock(void *unused)
+{
+    (void)unused;
+    test_memory[1] = 1;
+}
+
+static void test_cleanup(void)
+{
+    test_memory[2] = 1;
+}
+
+ATHRILL_EXDEV_EXPORT AthrillExDevTestDeviceType athrill_ex_device = {
+    {
+        ATHRILL_EXTERNAL_DEVICE_MAGICNO,
+        ATHRILL_EXTERNAL_DEVICE_VERSION,
+        (int)sizeof(test_memory)
+    },
+    test_memory,
+    NULL,
+    test_devinit,
+    test_supply_clock,
+    test_cleanup
+};

--- a/test/shared_library_test.c
+++ b/test/shared_library_test.c
@@ -1,0 +1,67 @@
+#include "shared_library.h"
+#include "exdev_test_abi.h"
+
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char *argv[])
+{
+    AthrillSharedLibraryHandle library;
+    AthrillExDevTestDeviceType *device;
+    char error_message[512];
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s EXDEV_LIBRARY\n", argv[0]);
+        return 1;
+    }
+
+    library = athrill_shared_library_open(
+        argv[1], error_message, sizeof(error_message));
+    if (library == NULL) {
+        fprintf(stderr, "failed to open EXDEV library: %s\n", error_message);
+        return 2;
+    }
+
+    device = (AthrillExDevTestDeviceType *)athrill_shared_library_symbol(
+        library, "athrill_ex_device", error_message, sizeof(error_message));
+    if (device == NULL) {
+        fprintf(stderr, "failed to resolve athrill_ex_device: %s\n",
+            error_message);
+        athrill_shared_library_close(library);
+        return 3;
+    }
+    if (device->header.magicno != ATHRILL_EXTERNAL_DEVICE_MAGICNO
+        || device->header.version != ATHRILL_EXTERNAL_DEVICE_VERSION
+        || device->header.memory_size != 64
+        || device->datap == NULL
+        || device->devinit == NULL
+        || device->supply_clock == NULL
+        || device->cleanup == NULL) {
+        fprintf(stderr, "invalid EXDEV ABI descriptor\n");
+        athrill_shared_library_close(library);
+        return 4;
+    }
+
+    device->devinit(NULL);
+    device->supply_clock(NULL);
+    device->cleanup();
+    if (device->datap[0] != 1 || device->datap[1] != 1
+        || device->datap[2] != 1) {
+        fprintf(stderr, "EXDEV callbacks were not invoked\n");
+        athrill_shared_library_close(library);
+        return 5;
+    }
+
+    error_message[0] = '\0';
+    if (athrill_shared_library_symbol(
+            library, "missing_exdev_symbol",
+            error_message, sizeof(error_message)) != NULL
+        || strlen(error_message) == 0U) {
+        fprintf(stderr, "missing symbol did not report an error\n");
+        athrill_shared_library_close(library);
+        return 6;
+    }
+
+    athrill_shared_library_close(library);
+    return 0;
+}

--- a/tools/hako.py
+++ b/tools/hako.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+
+COMPONENT_ID = "athrill-target-v850e2m"
+COMPONENT_VERSION = "1.0.2"
+VALID_BUILD_TYPES = {"Debug", "Release", "RelWithDebInfo", "MinSizeRel"}
+DEFAULT_CONFIG: dict[str, Any] = {
+    "version": 1,
+    "build": {"type": "Release", "dir": ".hako/build", "parallel": 0},
+    "features": {"exdev": False, "mros": False, "vdev": False},
+    "validation": {"tests": True},
+    "paths": {"athrill_root": "../athrill", "vcpkg_root": ""},
+}
+
+
+class ConfigError(RuntimeError):
+    pass
+
+
+def _strip_comment(text: str) -> str:
+    quote: str | None = None
+    escaped = False
+    out: list[str] = []
+    for ch in text:
+        if escaped:
+            out.append(ch)
+            escaped = False
+        elif ch == "\\" and quote:
+            out.append(ch)
+            escaped = True
+        elif ch in {"'", '"'}:
+            quote = None if quote == ch else ch if quote is None else quote
+            out.append(ch)
+        elif ch == "#" and quote is None:
+            break
+        else:
+            out.append(ch)
+    return "".join(out).rstrip()
+
+
+def _parse_scalar(text: str) -> Any:
+    value = text.strip()
+    if not value:
+        return {}
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered in {"null", "~"}:
+        return None
+    if value.startswith(("'", '"')):
+        if len(value) < 2 or value[-1] != value[0]:
+            raise ConfigError(f"unterminated quoted scalar: {value}")
+        if value[0] == '"':
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError as exc:
+                raise ConfigError(f"invalid quoted scalar: {value}") from exc
+        return value[1:-1].replace("''", "'")
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
+def load_simple_yaml(path: Path) -> dict[str, Any]:
+    root: dict[str, Any] = {}
+    stack: list[tuple[int, dict[str, Any]]] = [(-1, root)]
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise ConfigError(f"cannot read build manifest: {path}: {exc}") from exc
+    for lineno, raw in enumerate(lines, 1):
+        if "\t" in raw:
+            raise ConfigError(f"{path}:{lineno}: tabs are not allowed")
+        line = _strip_comment(raw)
+        if not line.strip():
+            continue
+        stripped = line.lstrip(" ")
+        indent = len(line) - len(stripped)
+        if stripped.startswith("-"):
+            raise ConfigError(f"{path}:{lineno}: sequences are not supported")
+        if ":" not in stripped:
+            raise ConfigError(f"{path}:{lineno}: expected 'key: value'")
+        key, raw_value = stripped.split(":", 1)
+        key = key.strip()
+        while stack and indent <= stack[-1][0]:
+            stack.pop()
+        if not key or not stack:
+            raise ConfigError(f"{path}:{lineno}: invalid mapping")
+        parent = stack[-1][1]
+        if key in parent:
+            raise ConfigError(f"{path}:{lineno}: duplicate key: {key}")
+        value = _parse_scalar(raw_value)
+        parent[key] = value
+        if isinstance(value, dict):
+            stack.append((indent, value))
+    return root
+
+
+def _merge_known(defaults: Mapping[str, Any], overrides: Mapping[str, Any], prefix: str = "") -> dict[str, Any]:
+    unknown = sorted(set(overrides) - set(defaults))
+    if unknown:
+        raise ConfigError(f"unknown key(s) under {prefix or 'root'}: {', '.join(unknown)}")
+    result: dict[str, Any] = {}
+    for key, default in defaults.items():
+        value = overrides.get(key, default)
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(default, Mapping):
+            if not isinstance(value, Mapping):
+                raise ConfigError(f"{path} must be a mapping")
+            result[key] = _merge_known(default, value, path)
+        else:
+            result[key] = value
+    return result
+
+
+def resolve_config(raw: Mapping[str, Any]) -> dict[str, Any]:
+    cfg = _merge_known(DEFAULT_CONFIG, raw)
+    if cfg["version"] != 1:
+        raise ConfigError("version must be 1")
+    if cfg["build"]["type"] not in VALID_BUILD_TYPES:
+        raise ConfigError("build.type must be Debug, Release, RelWithDebInfo, or MinSizeRel")
+    if not isinstance(cfg["build"]["dir"], str) or not cfg["build"]["dir"].strip():
+        raise ConfigError("build.dir must be a non-empty string")
+    parallel = cfg["build"]["parallel"]
+    if not isinstance(parallel, int) or isinstance(parallel, bool) or parallel < 0:
+        raise ConfigError("build.parallel must be a non-negative integer")
+    for key in ("exdev", "mros"):
+        if cfg["features"][key] not in {True, False, "auto"}:
+            raise ConfigError(f"features.{key} must be auto, true, or false")
+    for section, keys in {"features": ("vdev",), "validation": ("tests",)}.items():
+        for key in keys:
+            if not isinstance(cfg[section][key], bool):
+                raise ConfigError(f"{section}.{key} must be true or false")
+    for key in ("athrill_root", "vcpkg_root"):
+        if not isinstance(cfg["paths"][key], str):
+            raise ConfigError(f"paths.{key} must be a string")
+    return cfg
+
+
+def _host_platform() -> tuple[str, str]:
+    os_name = "windows" if sys.platform == "win32" else "macos" if sys.platform == "darwin" else "linux"
+    machine = platform.machine().lower()
+    arch = {"amd64": "x64", "x86_64": "x64", "arm64": "arm64", "aarch64": "arm64"}.get(machine, machine or "unknown")
+    return os_name, arch
+
+
+def _resolve_path(value: str, repo_root: Path) -> Path:
+    path = Path(value).expanduser()
+    return (repo_root / path).resolve() if not path.is_absolute() else path.resolve()
+
+
+def _find_vcpkg_root(cfg: Mapping[str, Any], repo_root: Path) -> Path | None:
+    candidates = [cfg["paths"]["vcpkg_root"], os.environ.get("VCPKG_ROOT", "")]
+    if sys.platform == "win32":
+        candidates += [r"C:\project\vcpkg", str(repo_root.parent / "vcpkg")]
+    for value in candidates:
+        if not value:
+            continue
+        path = _resolve_path(value, repo_root)
+        if (path / "scripts" / "buildsystems" / "vcpkg.cmake").is_file():
+            return path
+    return None
+
+
+def _find_vsdevcmd() -> Path | None:
+    install = os.environ.get("VSINSTALLDIR")
+    if install:
+        candidate = Path(install) / "Common7" / "Tools" / "VsDevCmd.bat"
+        if candidate.is_file():
+            return candidate
+    roots = [os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"), os.environ.get("ProgramFiles", r"C:\Program Files")]
+    for root in roots:
+        vswhere = Path(root) / "Microsoft Visual Studio" / "Installer" / "vswhere.exe"
+        if vswhere.is_file():
+            result = subprocess.run([str(vswhere), "-latest", "-products", "*", "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64", "-property", "installationPath"], capture_output=True, text=True, check=False)
+            if result.returncode == 0 and result.stdout.strip():
+                candidate = Path(result.stdout.strip()) / "Common7" / "Tools" / "VsDevCmd.bat"
+                if candidate.is_file():
+                    return candidate
+    return None
+
+
+@dataclass
+class BuildContext:
+    repo_root: Path
+    manifest: Path
+    cfg: dict[str, Any]
+    build_dir: Path
+    athrill_root: Path
+    vcpkg_root: Path | None
+    platform_name: str
+    arch: str
+    vsdevcmd: Path | None
+    dry_run: bool
+
+
+def create_context(manifest: Path, repo_root: Path, dry_run: bool = False) -> BuildContext:
+    cfg = resolve_config(load_simple_yaml(manifest))
+    platform_name, arch = _host_platform()
+    for feature in ("exdev", "mros"):
+        if cfg["features"][feature] == "auto":
+            cfg["features"][feature] = platform_name != "windows"
+    if platform_name == "windows" and any(cfg["features"].values()):
+        raise ConfigError("Windows currently requires features.exdev/mros/vdev=false")
+    return BuildContext(
+        repo_root=repo_root,
+        manifest=manifest,
+        cfg=cfg,
+        build_dir=_resolve_path(cfg["build"]["dir"], repo_root),
+        athrill_root=_resolve_path(cfg["paths"]["athrill_root"], repo_root),
+        vcpkg_root=_find_vcpkg_root(cfg, repo_root),
+        platform_name=platform_name,
+        arch=arch,
+        vsdevcmd=_find_vsdevcmd() if platform_name == "windows" else None,
+        dry_run=dry_run,
+    )
+
+
+def _command_path(path: Path, repo_root: Path) -> str:
+    try:
+        return os.path.relpath(path, repo_root)
+    except ValueError:
+        return str(path)
+
+
+def _run(ctx: BuildContext, command: list[str]) -> None:
+    print("+", subprocess.list2cmdline(command) if ctx.platform_name == "windows" else " ".join(command))
+    if ctx.dry_run:
+        return
+    if ctx.platform_name != "windows":
+        subprocess.run(command, cwd=ctx.repo_root, check=True)
+        return
+    if not ctx.vsdevcmd:
+        raise ConfigError("Visual Studio C++ developer environment was not found")
+    if not ctx.vcpkg_root:
+        raise ConfigError("vcpkg was not found; set paths.vcpkg_root or VCPKG_ROOT")
+    native = subprocess.list2cmdline(command)
+    script = (
+        f'call "{ctx.vsdevcmd}" -arch=x64 -host_arch=x64'
+        f' && pushd "{ctx.repo_root}"'
+        f' && set "VCPKG_ROOT={ctx.vcpkg_root}"'
+        f" && {native}"
+    )
+    # Pass a raw command line: list2cmdline escapes embedded quotes with
+    # backslashes, but cmd.exe does not use backslash as its quote escape.
+    subprocess.run("cmd.exe /d /c " + script, cwd=os.environ.get("SystemDrive", "C:") + "\\", check=True)
+
+
+def _cmake_bool(value: bool) -> str:
+    return "ON" if value else "OFF"
+
+
+def configure(ctx: BuildContext) -> None:
+    command = [
+        "cmake", "--fresh", "-S", ".", "-B", _command_path(ctx.build_dir, ctx.repo_root), "-G", "Ninja",
+        f'-DCMAKE_BUILD_TYPE={ctx.cfg["build"]["type"]}',
+        f'-DATHRILL_SOURCE_DIR={_command_path(ctx.athrill_root, ctx.repo_root)}',
+        f'-DATHRILL_ENABLE_EXDEV={_cmake_bool(ctx.cfg["features"]["exdev"])}',
+        f'-DATHRILL_ENABLE_MROS={_cmake_bool(ctx.cfg["features"]["mros"])}',
+        f'-DATHRILL_ENABLE_VDEV={_cmake_bool(ctx.cfg["features"]["vdev"])}',
+        f'-DBUILD_TESTING={_cmake_bool(ctx.cfg["validation"]["tests"])}',
+    ]
+    if ctx.platform_name == "windows":
+        if not ctx.vcpkg_root:
+            raise ConfigError("vcpkg was not found; set paths.vcpkg_root or VCPKG_ROOT")
+        command += [f'-DCMAKE_TOOLCHAIN_FILE={ctx.vcpkg_root / "scripts" / "buildsystems" / "vcpkg.cmake"}', "-DVCPKG_TARGET_TRIPLET=x64-windows-static"]
+    _run(ctx, command)
+    write_resolved(ctx)
+
+
+def build(ctx: BuildContext) -> None:
+    configure(ctx)
+    command = ["cmake", "--build", _command_path(ctx.build_dir, ctx.repo_root), "--config", ctx.cfg["build"]["type"]]
+    if ctx.cfg["build"]["parallel"]:
+        command += ["--parallel", str(ctx.cfg["build"]["parallel"])]
+    _run(ctx, command)
+
+
+def test(ctx: BuildContext) -> None:
+    if not ctx.cfg["validation"]["tests"]:
+        print("SKIP validation.tests=false")
+        return
+    _run(ctx, ["ctest", "--test-dir", _command_path(ctx.build_dir, ctx.repo_root), "-C", ctx.cfg["build"]["type"], "--output-on-failure"])
+
+
+def smoke(ctx: BuildContext) -> None:
+    test(ctx)
+
+
+def _yaml_scalar(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, int):
+        return str(value)
+    if value is None:
+        return "null"
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def _dump_yaml(data: Mapping[str, Any], indent: int = 0) -> str:
+    lines: list[str] = []
+    prefix = " " * indent
+    for key, value in data.items():
+        if isinstance(value, Mapping):
+            lines.append(f"{prefix}{key}:")
+            lines.append(_dump_yaml(value, indent + 2).rstrip())
+        else:
+            lines.append(f"{prefix}{key}: {_yaml_scalar(value)}")
+    return "\n".join(lines) + "\n"
+
+
+def _resolved_record(ctx: BuildContext) -> dict[str, Any]:
+    return {
+        "version": 1,
+        "component": COMPONENT_ID,
+        "source_manifest": str(ctx.manifest),
+        "platform": {"os": ctx.platform_name, "architecture": ctx.arch},
+        "build": {**ctx.cfg["build"], "dir": str(ctx.build_dir)},
+        "features": ctx.cfg["features"],
+        "validation": ctx.cfg["validation"],
+        "paths": {"athrill_root": str(ctx.athrill_root), "vcpkg_root": str(ctx.vcpkg_root or "")},
+    }
+
+
+def write_resolved(ctx: BuildContext) -> Path:
+    path = ctx.repo_root / ".hako" / "resolved-build.yaml"
+    if not ctx.dry_run:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(_dump_yaml(_resolved_record(ctx)), encoding="utf-8")
+    return path
+
+
+def _git_revision(repo: Path) -> str:
+    result = subprocess.run(
+        ["git", "-c", f"safe.directory={repo}", "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def write_receipt(ctx: BuildContext, install_dir: Path) -> Path:
+    executable = Path("bin") / ("athrill2.exe" if ctx.platform_name == "windows" else "athrill2")
+    if not (install_dir / executable).is_file():
+        raise ConfigError(f"installed executable not found: {install_dir / executable}")
+    receipt_root = install_dir / "share" / "hakoniwa" / "receipts"
+    resolved_relative = Path("share/hakoniwa/receipts/resolved") / f"{COMPONENT_ID}.yaml"
+    receipt = receipt_root / f"{COMPONENT_ID}.yaml"
+    capabilities = {
+        "target_v850e2m": True,
+        "usage_smoke": ctx.cfg["validation"]["tests"],
+        **ctx.cfg["features"],
+    }
+    lines = [
+        "schema_version: 1",
+        "component:",
+        f"  id: {COMPONENT_ID}",
+        f"  version: {COMPONENT_VERSION}",
+        f"  source_revision: {_yaml_scalar(_git_revision(ctx.repo_root))}",
+        "platform:",
+        f"  os: {ctx.platform_name}",
+        f"  architecture: {ctx.arch}",
+        f"  toolchain: {'msvc' if ctx.platform_name == 'windows' else 'host-default'}",
+        "install:",
+        f"  prefix: {_yaml_scalar(install_dir)}",
+        "capabilities:",
+    ]
+    for key, value in capabilities.items():
+        lines.append(f"  {key}: {_yaml_scalar(value)}")
+    lines += [
+        "build_limits: {}",
+        "dependencies: {}",
+        "artifacts:",
+        f"  - path: {_yaml_scalar(executable.as_posix())}",
+        "    kind: executable",
+        f"resolved_manifest: {_yaml_scalar(resolved_relative.as_posix())}",
+    ]
+    if not ctx.dry_run:
+        receipt_root.mkdir(parents=True, exist_ok=True)
+        stored = install_dir / resolved_relative
+        stored.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(write_resolved(ctx), stored)
+        receipt.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return receipt
+
+
+def install(ctx: BuildContext, install_dir: Path) -> None:
+    _run(ctx, ["cmake", "--install", _command_path(ctx.build_dir, ctx.repo_root), "--config", ctx.cfg["build"]["type"], "--prefix", _command_path(install_dir, ctx.repo_root)])
+    print(f"Receipt: {write_receipt(ctx, install_dir)}")
+
+
+def doctor(ctx: BuildContext) -> bool:
+    checks = {
+        "cmake": shutil.which("cmake") is not None,
+        "ninja": shutil.which("ninja") is not None,
+        "athrill common CMake": (ctx.athrill_root / "cmake" / "AthrillCore.cmake").is_file(),
+    }
+    if ctx.platform_name == "windows":
+        checks["Visual Studio C++"] = ctx.vsdevcmd is not None
+        checks["vcpkg"] = ctx.vcpkg_root is not None
+    for name, ok in checks.items():
+        print(f"{'OK' if ok else 'NG'} {name}")
+    print(f"INFO platform={ctx.platform_name}/{ctx.arch}")
+    print(f"INFO build_dir={ctx.build_dir}")
+    print(f"INFO athrill_root={ctx.athrill_root}")
+    if ctx.vcpkg_root:
+        print(f"INFO vcpkg_root={ctx.vcpkg_root}")
+    if ctx.platform_name == "windows" and str(ctx.repo_root).startswith("\\\\"):
+        print("INFO UNC workspace detected; hako.py will map it with cmd pushd")
+    return all(checks.values())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Business Pack build entry point for Athrill V850E2M")
+    parser.add_argument("--config", help="build manifest (default: repository root/hakoniwa-build.yaml)")
+    parser.add_argument("--install-dir", help="install prefix (required for install)")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("operation", choices=("doctor", "configure", "build", "test", "install", "smoke"))
+    args = parser.parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[1]
+    manifest = Path(args.config).resolve() if args.config else repo_root / "hakoniwa-build.yaml"
+    try:
+        ctx = create_context(manifest, repo_root, args.dry_run)
+        if args.operation == "doctor":
+            return 0 if doctor(ctx) else 1
+        if args.operation == "configure":
+            configure(ctx)
+        elif args.operation == "build":
+            build(ctx)
+        elif args.operation == "test":
+            test(ctx)
+        elif args.operation == "smoke":
+            smoke(ctx)
+        elif args.operation == "install":
+            if not args.install_dir:
+                raise ConfigError("install requires --install-dir")
+            install(ctx, Path(args.install_dir).resolve())
+        return 0
+    except (ConfigError, subprocess.CalledProcessError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/hako.py
+++ b/tools/hako.py
@@ -19,7 +19,7 @@ VALID_BUILD_TYPES = {"Debug", "Release", "RelWithDebInfo", "MinSizeRel"}
 DEFAULT_CONFIG: dict[str, Any] = {
     "version": 1,
     "build": {"type": "Release", "dir": ".hako/build", "parallel": 0},
-    "features": {"exdev": False, "mros": False, "vdev": False},
+    "features": {"exdev": True, "mros": False, "vdev": False},
     "validation": {"tests": True},
     "paths": {"athrill_root": "../athrill", "vcpkg_root": ""},
 }
@@ -212,11 +212,14 @@ class BuildContext:
 def create_context(manifest: Path, repo_root: Path, dry_run: bool = False) -> BuildContext:
     cfg = resolve_config(load_simple_yaml(manifest))
     platform_name, arch = _host_platform()
-    for feature in ("exdev", "mros"):
-        if cfg["features"][feature] == "auto":
-            cfg["features"][feature] = platform_name != "windows"
-    if platform_name == "windows" and any(cfg["features"].values()):
-        raise ConfigError("Windows currently requires features.exdev/mros/vdev=false")
+    if cfg["features"]["exdev"] == "auto":
+        cfg["features"]["exdev"] = True
+    if cfg["features"]["mros"] == "auto":
+        cfg["features"]["mros"] = False
+    if platform_name == "windows" and (
+        cfg["features"]["mros"] or cfg["features"]["vdev"]
+    ):
+        raise ConfigError("Windows currently requires features.mros/vdev=false")
     return BuildContext(
         repo_root=repo_root,
         manifest=manifest,

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "athrill-target-v850e2m",
+  "version-string": "1.0.2",
+  "dependencies": [
+    "getopt-win32",
+    "pthreads"
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,6 @@
   "name": "athrill-target-v850e2m",
   "version-string": "1.0.2",
   "dependencies": [
-    "getopt-win32",
     "pthreads"
   ]
 }


### PR DESCRIPTION
## What changed

- modernize the V850E2M target CMake graph
- add native MSVC and vcpkg support
- add a component-owned `hako.py` lifecycle and Foundation Receipt
- remove the getopt-win32 dependency
- enable and test cross-platform EXDEV loading
- update the Athrill source reference to the matching argument-parser and shared-library implementation

## Why

The V850E2M emulator must be reproducible through Hakoniwa Business Pack on Linux, macOS, and native Windows without requiring MinGW-specific build behavior.

## Impact

The target can be configured, built, tested, installed, and inspected through the same component contract used by other Foundation components.

## Dependency

This PR consumes the portable common-source changes proposed by the `toppers/athrill` `hakoniwa → master` PR and should be merged after it.

## Validation

- native Windows/MSVC build verified
- clean macOS build with the recorded Athrill revision
- CTest passed 3/3: usage, argument parser, and EXDEV shared-library loading
- Business Pack Foundation adapter tests passed
