### PR TITLE
Use the host CMake generator on POSIX

### DIFF
--- a/test/test_hako.py
+++ b/test/test_hako.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from tools import hako
+
+
+class HakoConfigureTest(unittest.TestCase):
+    def context(self, platform_name: str) -> hako.BuildContext:
+        temporary = Path(tempfile.mkdtemp())
+        cfg = hako.resolve_config({})
+        return hako.BuildContext(
+            repo_root=temporary / "target",
+            manifest=temporary / "target" / "hakoniwa-build.yaml",
+            cfg=cfg,
+            build_dir=temporary / "build",
+            athrill_root=temporary / "athrill",
+            vcpkg_root=temporary / "vcpkg" if platform_name == "windows" else None,
+            platform_name=platform_name,
+            arch="x64",
+            vsdevcmd=temporary / "VsDevCmd.bat" if platform_name == "windows" else None,
+            dry_run=True,
+        )
+
+    def test_posix_uses_host_default_generator(self) -> None:
+        for platform_name in ("macos", "linux"):
+            with self.subTest(platform_name=platform_name):
+                command = hako.configure_command(self.context(platform_name))
+                self.assertNotIn("-G", command)
+                self.assertNotIn("Ninja", command)
+
+    def test_windows_keeps_ninja_and_vcpkg(self) -> None:
+        command = hako.configure_command(self.context("windows"))
+        self.assertIn("Ninja", command)
+        self.assertTrue(
+            any(item.startswith("-DCMAKE_TOOLCHAIN_FILE=") for item in command)
+        )
+        self.assertIn("-DVCPKG_TARGET_TRIPLET=x64-windows-static", command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/hako.py
+++ b/tools/hako.py
@@ -268,9 +268,9 @@ def _cmake_bool(value: bool) -> str:
     return "ON" if value else "OFF"
 
 
-def configure(ctx: BuildContext) -> None:
+def configure_command(ctx: BuildContext) -> list[str]:
     command = [
-        "cmake", "--fresh", "-S", ".", "-B", _command_path(ctx.build_dir, ctx.repo_root), "-G", "Ninja",
+        "cmake", "--fresh", "-S", ".", "-B", _command_path(ctx.build_dir, ctx.repo_root),
         f'-DCMAKE_BUILD_TYPE={ctx.cfg["build"]["type"]}',
         f'-DATHRILL_SOURCE_DIR={_command_path(ctx.athrill_root, ctx.repo_root)}',
         f'-DATHRILL_ENABLE_EXDEV={_cmake_bool(ctx.cfg["features"]["exdev"])}',
@@ -281,8 +281,16 @@ def configure(ctx: BuildContext) -> None:
     if ctx.platform_name == "windows":
         if not ctx.vcpkg_root:
             raise ConfigError("vcpkg was not found; set paths.vcpkg_root or VCPKG_ROOT")
-        command += [f'-DCMAKE_TOOLCHAIN_FILE={ctx.vcpkg_root / "scripts" / "buildsystems" / "vcpkg.cmake"}', "-DVCPKG_TARGET_TRIPLET=x64-windows-static"]
-    _run(ctx, command)
+        command += [
+            "-G", "Ninja",
+            f'-DCMAKE_TOOLCHAIN_FILE={ctx.vcpkg_root / "scripts" / "buildsystems" / "vcpkg.cmake"}',
+            "-DVCPKG_TARGET_TRIPLET=x64-windows-static",
+        ]
+    return command
+
+
+def configure(ctx: BuildContext) -> None:
+    _run(ctx, configure_command(ctx))
     write_resolved(ctx)
 
 
@@ -411,10 +419,10 @@ def install(ctx: BuildContext, install_dir: Path) -> None:
 def doctor(ctx: BuildContext) -> bool:
     checks = {
         "cmake": shutil.which("cmake") is not None,
-        "ninja": shutil.which("ninja") is not None,
         "athrill common CMake": (ctx.athrill_root / "cmake" / "AthrillCore.cmake").is_file(),
     }
     if ctx.platform_name == "windows":
+        checks["ninja"] = shutil.which("ninja") is not None
         checks["Visual Studio C++"] = ctx.vsdevcmd is not None
         checks["vcpkg"] = ctx.vcpkg_root is not None
     for name, ok in checks.items():


### PR DESCRIPTION
## What changed

- use CMake's host-default generator on macOS and Linux
- keep Ninja, MSVC initialization, and vcpkg selection on native Windows
- limit the Ninja doctor prerequisite to Windows
- add unit tests for the POSIX and Windows generator contracts

## Why

The component-owned `hako.py` unconditionally selected Ninja, although the portable POSIX build works with the host CMake generator. This caused the generic Business Pack Recipe to stop in doctor on a clean macOS host without Ninja.

## Impact

macOS and Linux no longer need an unnecessary Ninja installation. The verified native Windows toolchain remains unchanged.

## Validation

- Python platform-adapter tests passed 2/2
- Business Pack generic Recipe configure completed on macOS arm64
- target CTest passed 3/3
- install, Component Receipt, and Foundation SATISFIED evaluation passed
